### PR TITLE
Fixed issue with engine path being set incorrectly in registry key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains in-progress instructions on how to create a "Launcher" 
 
 It can successfully build the engine. Stand-alone games can be packaged with them. It is easy to distribute one-off custom engine builds to an entire team.
 
-Testing has been done with UE4 4.11.2 on a Windows 10 machine, targetting Win64.
+Testing has been done with UE4 4.11.2 & 4.12.0 on a Windows 10 machine, targetting Win64.
 
 ## Usage
 

--- a/RegisterEngineVersion.cmd
+++ b/RegisterEngineVersion.cmd
@@ -16,6 +16,6 @@ echo Installing prerequisites...
 start /wait Engine\Extras\Redist\en-us\UE4PrereqSetup_x64.exe /quiet
 
 rem Register the engine installation...
-reg add "HKEY_CURRENT_USER\SOFTWARE\Epic Games\Unreal Engine\Builds" /f /v "%1" /t REG_SZ /d %~dp0
+reg add "HKEY_CURRENT_USER\SOFTWARE\Epic Games\Unreal Engine\Builds" /f /v "%1" /t REG_SZ /d "%~dp0"
 
 )

--- a/RegisterEngineVersion.cmd
+++ b/RegisterEngineVersion.cmd
@@ -16,6 +16,6 @@ echo Installing prerequisites...
 start /wait Engine\Extras\Redist\en-us\UE4PrereqSetup_x64.exe /quiet
 
 rem Register the engine installation...
-reg add "HKEY_CURRENT_USER\SOFTWARE\Epic Games\Unreal Engine\Builds" /f /v "%1" /t REG_SZ /d ".\"
+reg add "HKEY_CURRENT_USER\SOFTWARE\Epic Games\Unreal Engine\Builds" /f /v "%1" /t REG_SZ /d %~dp0
 
 )


### PR DESCRIPTION
I thought this was committed before I submitted pull request #1 - opps!

registry key value (path) was incorrect, now sets it to current .bat directory (%~dp0)

Also works fine with 4.12 which I added to the readme.
