### PR TITLE
%~dp0 in quotes was leaving a " at the end of path

### DIFF
--- a/RegisterEngineVersion.cmd
+++ b/RegisterEngineVersion.cmd
@@ -16,6 +16,6 @@ echo Installing prerequisites...
 start /wait Engine\Extras\Redist\en-us\UE4PrereqSetup_x64.exe /quiet
 
 rem Register the engine installation...
-reg add "HKEY_CURRENT_USER\SOFTWARE\Epic Games\Unreal Engine\Builds" /f /v "%1" /t REG_SZ /d "%~dp0"
+reg add "HKEY_CURRENT_USER\SOFTWARE\Epic Games\Unreal Engine\Builds" /f /v "%1" /t REG_SZ /d "%~dp0\"
 
 )


### PR DESCRIPTION
Just noticed this when running the script on my colleagues machine. I've added a \ after the %~dp0 so that the last backslash doesn't act like an escape character leaving a " at the end of the path.
